### PR TITLE
chore(deps-dev): upgrade @types/node to ^18.0.0 to resolve dependency conflict with Vite

### DIFF
--- a/hello-world-bot-with-tab/bot/package.json
+++ b/hello-world-bot-with-tab/bot/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {
         "@types/restify": "8.5.5",
         "@types/json-schema": "^7.0.15",
-        "@types/node": "^14.0.0",
+        "@types/node": "^18.0.0",
         "env-cmd": "^10.1.0",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4",

--- a/hello-world-bot-with-tab/tab/package.json
+++ b/hello-world-bot-with-tab/tab/package.json
@@ -16,7 +16,7 @@
     "react-router-dom": "^6.8.0"
   },
   "devDependencies": {
-    "@types/node": "^14.0.0",
+    "@types/node": "^18.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/react-router-dom": "^5.3.3",


### PR DESCRIPTION
## Description
This pull request addresses an issue that arose following PR #1328, which migrated the project from React scripts to Vite. During the migration, the **@types/node** dependency needed to be updated to ensure compatibility with Vite and avoid peer dependency conflicts.

Without updating **@types/node** to `^18.0.0`, local debugging fails with the following error message:

```
[Error] - Failed to Execute lifecycle deploy due to failed action: cli/runNpmCommand. 
ScriptExecutionError: Unable to execute script action. 
Env output: {"SSL_CRT_FILE":"/path/to/hidden/localhost.crt","SSL_KEY_FILE":"/path/to/hidden/localhost.key"}
```
This error occurs because Vite and its plugins require **@types/node** version `^18.0.0` or higher, but the project was still using **@types/node** `14.x.x`, causing a conflict. By upgrading **@types/node** to `^18.0.0` in both the tab and bot package.json files, this conflict is resolved, and local debugging succeeds.

## Changes Made
Updated **@types/node** to `^18.0.0` in both **tab** and **bot** `package.json` files to resolve conflicts with Vite and its related plugins.

## Related Pull Request
PR: [#1328](https://github.com/OfficeDev/teams-toolkit-samples/pull/1328) (Migrated project from React scripts to Vite)